### PR TITLE
Cj get all categories

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+## Screenshots (if appropriate):
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.

--- a/rareapi/urls.py
+++ b/rareapi/urls.py
@@ -1,21 +1,12 @@
-"""rareapi URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-from django.contrib import admin
 from django.urls import path
+from rest_framework import routers
+from rareserverapi.views import Categories
+from django.conf.urls import include
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'categories', Categories, 'category')
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('', include(router.urls)),
+    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/rareserverapi/fixtures/postreactions.json
+++ b/rareserverapi/fixtures/postreactions.json
@@ -1,5 +1,5 @@
 [{
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 1,
     "fields": {
       "reactor": 5,
@@ -7,7 +7,7 @@
       "post": 9
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 2,
     "fields": {
       "reactor": 1,
@@ -15,7 +15,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 3,
     "fields": {
       "reactor": 5,
@@ -23,7 +23,7 @@
       "post": 7
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 4,
     "fields": {
       "reactor": 4,
@@ -31,7 +31,7 @@
       "post": 10
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 5,
     "fields": {
       "reactor": 5,
@@ -39,7 +39,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 6,
     "fields": {
       "reactor": 3,
@@ -47,7 +47,7 @@
       "post": 8
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 7,
     "fields": {
       "reactor": 3,
@@ -55,7 +55,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 8,
     "fields": {
       "reactor": 4,
@@ -63,7 +63,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 9,
     "fields": {
       "reactor": 3,
@@ -71,7 +71,7 @@
       "post": 4
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 10,
     "fields": {
       "reactor": 1,
@@ -79,7 +79,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 11,
     "fields": {
       "reactor": 1,
@@ -87,7 +87,7 @@
       "post": 4
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 12,
     "fields": {
       "reactor": 4,
@@ -95,7 +95,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 13,
     "fields": {
       "reactor": 2,
@@ -103,7 +103,7 @@
       "post": 2
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 14,
     "fields": {
       "reactor": 3,
@@ -111,7 +111,7 @@
       "post": 7
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 15,
     "fields": {
       "reactor": 3,
@@ -119,7 +119,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 16,
     "fields": {
       "reactor": 1,
@@ -127,7 +127,7 @@
       "post": 4
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 17,
     "fields": {
       "reactor": 2,
@@ -135,7 +135,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 18,
     "fields": {
       "reactor": 3,
@@ -143,7 +143,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 19,
     "fields": {
       "reactor": 2,
@@ -151,7 +151,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 20,
     "fields": {
       "reactor": 4,
@@ -159,7 +159,7 @@
       "post": 10
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 21,
     "fields": {
       "reactor": 3,
@@ -167,7 +167,7 @@
       "post": 2
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 22,
     "fields": {
       "reactor": 1,
@@ -175,7 +175,7 @@
       "post": 6
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 23,
     "fields": {
       "reactor": 2,
@@ -183,7 +183,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 24,
     "fields": {
       "reactor": 1,
@@ -191,7 +191,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 25,
     "fields": {
       "reactor": 2,
@@ -199,7 +199,7 @@
       "post": 6
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 26,
     "fields": {
       "reactor": 1,
@@ -207,7 +207,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 27,
     "fields": {
       "reactor": 1,
@@ -215,7 +215,7 @@
       "post": 4
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 28,
     "fields": {
       "reactor": 1,
@@ -223,7 +223,7 @@
       "post": 9
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 29,
     "fields": {
       "reactor": 5,
@@ -231,7 +231,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 30,
     "fields": {
       "reactor": 3,
@@ -239,7 +239,7 @@
       "post": 8
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 31,
     "fields": {
       "reactor": 3,
@@ -247,7 +247,7 @@
       "post": 9
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 32,
     "fields": {
       "reactor": 3,
@@ -255,7 +255,7 @@
       "post": 7
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 33,
     "fields": {
       "reactor": 2,
@@ -263,7 +263,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 34,
     "fields": {
       "reactor": 1,
@@ -271,7 +271,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 35,
     "fields": {
       "reactor": 5,
@@ -279,7 +279,7 @@
       "post": 2
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 36,
     "fields": {
       "reactor": 2,
@@ -287,7 +287,7 @@
       "post": 9
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 37,
     "fields": {
       "reactor": 4,
@@ -295,7 +295,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 38,
     "fields": {
       "reactor": 5,
@@ -303,7 +303,7 @@
       "post": 1
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 39,
     "fields": {
       "reactor": 4,
@@ -311,7 +311,7 @@
       "post": 10
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 40,
     "fields": {
       "reactor": 4,
@@ -319,7 +319,7 @@
       "post": 10
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 41,
     "fields": {
       "reactor": 4,
@@ -327,7 +327,7 @@
       "post": 7
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 42,
     "fields": {
       "reactor": 2,
@@ -335,7 +335,7 @@
       "post": 4
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 43,
     "fields": {
       "reactor": 1,
@@ -343,7 +343,7 @@
       "post": 2
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 44,
     "fields": {
       "reactor": 5,
@@ -351,7 +351,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 45,
     "fields": {
       "reactor": 2,
@@ -359,7 +359,7 @@
       "post": 9
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 46,
     "fields": {
       "reactor": 5,
@@ -367,7 +367,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 47,
     "fields": {
       "reactor": 3,
@@ -375,7 +375,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 48,
     "fields": {
       "reactor": 1,
@@ -383,7 +383,7 @@
       "post": 5
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 49,
     "fields": {
       "reactor": 1,
@@ -391,7 +391,7 @@
       "post": 3
     }
   }, {
-    "model": "rareserverapi.postreactions",
+    "model": "rareserverapi.postreaction",
     "pk": 50,
     "fields": {
       "reactor": 4,

--- a/rareserverapi/fixtures/tokens.json
+++ b/rareserverapi/fixtures/tokens.json
@@ -1,0 +1,10 @@
+[
+    {
+        "model": "authtoken.token",
+        "pk": "fa2eba9be8282d595c997ee5cd49f2ed31f65bed",
+        "fields": {
+            "user": 1,
+            "created": "2020-08-29T13:24:27.172Z"
+        }
+    }
+]

--- a/rareserverapi/fixtures/users.json
+++ b/rareserverapi/fixtures/users.json
@@ -4,7 +4,7 @@
   "fields": {
     "password": "1qIkMRJYDaVc",
     "last_login": null,
-    "is_supervisor": false,
+    "is_superuser": false,
     "username": "kgrigorian0@umn.edu",
     "first_name": "Koralle",
     "last_name": "Grigorian",
@@ -21,7 +21,7 @@
   "fields": {
     "password": "vi6rdZ3sA1dY",
     "last_login": null,
-    "is_supervisor": false,
+    "is_superuser": false,
     "username": "arusk1@example.com",
     "first_name": "Antonina",
     "last_name": "Rusk",
@@ -38,7 +38,7 @@
   "fields": {
     "password": "g4p5Akl1t",
     "last_login": null,
-    "is_supervisor": false,
+    "is_superuser": false,
     "username": "ncharnock2@domainmarket.com",
     "first_name": "Nelly",
     "last_name": "Charnock",
@@ -55,7 +55,7 @@
   "fields": {
     "password": "o1cMtgTUZOV5",
     "last_login": null,
-    "is_supervisor": false,
+    "is_superuser": false,
     "username": "ivamplers3@senate.gov",
     "first_name": "Inglis",
     "last_name": "Vamplers",
@@ -72,7 +72,7 @@
   "fields": {
     "password": "83eMQt",
     "last_login": null,
-    "is_supervisor": false,
+    "is_superuser": false,
     "username": "jwathen4@tmall.com",
     "first_name": "Jennica",
     "last_name": "Wathen",

--- a/rareserverapi/views/__init__.py
+++ b/rareserverapi/views/__init__.py
@@ -1,0 +1,1 @@
+from .category import Categories

--- a/rareserverapi/views/category.py
+++ b/rareserverapi/views/category.py
@@ -1,0 +1,48 @@
+""" View module for handling requests for categories """
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rareserverapi.models import Category
+
+class Categories(ViewSet):
+    """ rare category types """
+
+    def retrieve(self, request, pk=None):
+        """ Handle Get requests for a single category type
+        Returns: 
+            Response -- JSON serialized category type
+    """
+        try:
+            category = Category.objects.get(pk=pk)
+            serializer = CategorySerializer(category, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """ Handle GET requests to get all categories 
+        Returns:
+            Response -- JSON serialized list of category types
+        """
+        categories = Category.objects.all()
+
+        # Note the addtional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = CategorySerializer(
+            categories, many=True, context={'request': request})
+        return Response(serializer.data)
+
+class CategorySerializer(serializers.HyperlinkedModelSerializer):
+    """ JSON Serializer for category types 
+    Arguments: 
+        serializers
+    """
+    class Meta:
+        model = Category
+        url = serializers.HyperlinkedIdentityField(
+            view_name='category',
+            lookup_field='id'
+        )
+        fields = ('id', 'label')


### PR DESCRIPTION
Category views
## Description
created the url routing, and view set for categories
## Motivation and Context
Added new functionality to the server
## How Has This Been Tested?
Tested via Postman
## Steps to test
- `git fetch --all`
- `git checkout cj-get-all-categories`
- make sure you are in virtual environment, run `python manage.py loaddata tokens.json` 
- in postman, paste the token into the `headers` under `authorization`
- GET `http://localhost:8000/categories` should return all categories
- GET `http://localhost:8000/categories/1` should return a single category.
## Screenshots (if appropriate):
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.