### PR TITLE
login returns admin status

### DIFF
--- a/rare.session.sql
+++ b/rare.session.sql
@@ -1,0 +1,3 @@
+UPDATE auth_user
+SET is_staff = TRUE
+WHERE id = 6

--- a/rare.session.sql
+++ b/rare.session.sql
@@ -1,3 +1,0 @@
-UPDATE auth_user
-SET is_staff = TRUE
-WHERE id = 6

--- a/rareserverapi/views/auth.py
+++ b/rareserverapi/views/auth.py
@@ -29,7 +29,8 @@ def login_user(request):
         # If authentication was successful, respond with their token
         if authenticated_user is not None:
             token = Token.objects.get(user=authenticated_user)
-            data = json.dumps({"valid": True, "token": token.key})
+            rare_user = RareUser.objects.get(user=authenticated_user)
+            data = json.dumps({"valid": True, "token": token.key, "isAdmin": rare_user.user.is_staff })
             return HttpResponse(data, content_type='application/json')
 
         else:


### PR DESCRIPTION
## Description
Returns `is_staff` status on login request

## Motivation and Context
In order to dynamically display the Category Manager (and future admin-only features) the client needs data that indicated whether the current user is an administrator.

## How Has This Been Tested?
run in terminal:
```
git fetch --all
git checkout ps-admin
```
In Postman, perform a `POST` call with your credentials as follows on server `localhost:8000/login` with your credentials in the body as JSON:
```
{ "username": "[your username]", "password": "[your password]" }
```
The server should return an `isAdmin` key with a value of `true` or `false`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.